### PR TITLE
Manage topics from admin page in Target MVD

### DIFF
--- a/app/admin/targets.rb
+++ b/app/admin/targets.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Target do
-  config.sort_order = 'topic_asc'
+  config.sort_order = 'created_at_desc'
   config.per_page = [10, 50, 100]
 
   actions :index, :show
@@ -16,6 +16,7 @@ ActiveAdmin.register Target do
 
   filter :title
   filter :topic, as: :select
+  filter :topic_title_cont, label: 'Topic Title'
   filter :area_lenght, as: :numeric
   filter :user
   filter :user_name_cont, label: 'User Name'

--- a/app/admin/topics.rb
+++ b/app/admin/topics.rb
@@ -1,0 +1,20 @@
+ActiveAdmin.register Topic do
+  permit_params :title
+  config.sort_order = 'title_asc'
+
+  index do
+    selectable_column
+    id_column
+    column :title
+    actions
+  end
+
+  filter :title
+
+  form do |f|
+    f.inputs do
+      f.input :title
+    end
+    f.actions
+  end
+end

--- a/app/controllers/api/v1/targets_controller.rb
+++ b/app/controllers/api/v1/targets_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class TargetsController < ApiController
       def index
-        @targets = user_targets
+        @targets = user_targets.includes(:topic)
       end
 
       def create
@@ -25,7 +25,7 @@ module Api
       private
 
       def target_params
-        params.require(:target).permit(:area_lenght, :title, :topic, :latitude, :longitude)
+        params.require(:target).permit(:area_lenght, :title, :topic_id, :latitude, :longitude)
       end
 
       def user_targets

--- a/app/controllers/api/v1/topics_controller.rb
+++ b/app/controllers/api/v1/topics_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class TopicsController < ApiController
+      def index
+        @topics = Topic.all
+      end
+    end
+  end
+end

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -6,34 +6,21 @@
 #  user_id     :bigint           not null
 #  area_lenght :integer          not null
 #  title       :string           not null
-#  topic       :integer          not null
 #  latitude    :float            not null
 #  longitude   :float            not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  location    :text
+#  topic_id    :bigint           not null
 #
 
 class Target < ApplicationRecord
   MAX_TARGETS_PER_USER = 10
 
-  enum topic:
-  {
-    football: 0,
-    travel: 1,
-    politics: 2,
-    art: 3,
-    dating: 4,
-    music: 5,
-    movies: 6,
-    series: 7,
-    food: 8
-  }
-
   belongs_to :user
+  belongs_to :topic
 
   validates :area_lenght, :title, presence: true
-  validates :topic, presence: true, inclusion: { in: topics.keys }
   validates :latitude, presence: true,
                        numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
   validates :longitude, presence: true,

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -11,5 +11,5 @@
 class Topic < ApplicationRecord
   has_many :targets, dependent: :destroy
 
-  validates :title, presence: true
+  validates :title, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: topics
+#
+#  id         :bigint           not null, primary key
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Topic < ApplicationRecord
+  has_many :targets, dependent: :destroy
+
+  validates :title, presence: true
+end

--- a/app/views/api/v1/targets/_info.json.jbuilder
+++ b/app/views/api/v1/targets/_info.json.jbuilder
@@ -2,6 +2,6 @@ json.id           target.id
 json.user_id      target.user_id
 json.area_lenght  target.area_lenght
 json.title        target.title
-json.topic        target.topic
 json.latitude     target.latitude
 json.longitude    target.longitude
+json.topic        target.topic, partial: 'api/v1/topics/info', as: :topic

--- a/app/views/api/v1/topics/_info.json.jbuilder
+++ b/app/views/api/v1/topics/_info.json.jbuilder
@@ -1,0 +1,2 @@
+json.id         topic.id
+json.title      topic.title

--- a/app/views/api/v1/topics/index.json.jbuilder
+++ b/app/views/api/v1/topics/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.topics @topics, partial: 'info', as: :topic

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
         end
         resources :contact_admin, only: %i[create]
         resources :general_informations, only: :show, param: :key
+        resources :topics, only: :index
       end
     end
   end

--- a/db/migrate/20190807202020_create_topics.rb
+++ b/db/migrate/20190807202020_create_topics.rb
@@ -1,0 +1,13 @@
+class CreateTopics < ActiveRecord::Migration[5.2]
+  def change
+    create_table :topics do |t|
+      t.string :title, null: false
+
+      t.timestamps
+    end
+
+    %w[football travel politics art dating music movies series food].each do |topic|
+      Topic.create! title: topic
+    end
+  end
+end

--- a/db/migrate/20190807202020_create_topics.rb
+++ b/db/migrate/20190807202020_create_topics.rb
@@ -6,8 +6,6 @@ class CreateTopics < ActiveRecord::Migration[5.2]
       t.timestamps
     end
 
-    %w[football travel politics art dating music movies series food].each do |topic|
-      Topic.create! title: topic
-    end
+    add_index :topics, :title, unique: true
   end
 end

--- a/db/migrate/20190807203759_add_topic_reference_to_target.rb
+++ b/db/migrate/20190807203759_add_topic_reference_to_target.rb
@@ -1,0 +1,6 @@
+class AddTopicReferenceToTarget < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :targets, :topic
+    add_reference :targets, :topic, foreign_key: true, index: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,14 +97,21 @@ ActiveRecord::Schema.define(version: 2019_08_08_172853) do
     t.bigint "user_id", null: false
     t.integer "area_lenght", null: false
     t.string "title", null: false
-    t.integer "topic", null: false
     t.float "latitude", null: false
     t.float "longitude", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "location"
+    t.bigint "topic_id", null: false
     t.index ["latitude", "longitude"], name: "index_targets_on_latitude_and_longitude"
+    t.index ["topic_id"], name: "index_targets_on_topic_id"
     t.index ["user_id"], name: "index_targets_on_user_id"
+  end
+
+  create_table "topics", force: :cascade do |t|
+    t.string "title", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -134,4 +141,5 @@ ActiveRecord::Schema.define(version: 2019_08_08_172853) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "targets", "topics"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,4 +10,9 @@ GeneralInformation.find_or_create_by!(
   key: 'about',
   title: "WHAT'S TARGET?",
   text: "Cat ipsum dolor sit amet, scratch the furniture. Spit up on light gray carpet instead of adjacent linoleum cough furball yet lounge in doorway but gnaw the corn cob and sit by the fire rub face on everything. Flop over under the bed, or immediately regret falling into bathtub but swat turds around the house. All of a sudden cat goes crazy bleghbleghvomit my furball really tie the room together for destroy couch. Need to chase tail inspect anything brought into the house, yet sleep on dog bed, force dog to sleep on floor. Cat snacks. Eat owner's food nap all day, for chase imaginary bugs, yet throwup on your pillow. Bleghbleghvomit my furball really tie the room together sun bathe attack the dog then pretend like nothing happened Gate keepers of hell and destroy couch, so find empty spot in cupboard and sleep all day groom yourself 4 hours - checked, have your beauty sleep 18 hours - checked, be fabulous for the rest of the day - checked!.")
+
 AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password') if Rails.env.development?
+
+%w[football travel politics art dating music movies series food].each do |topic|
+  Topic.find_or_create_by! title: topic
+end

--- a/spec/factories/general_information.rb
+++ b/spec/factories/general_information.rb
@@ -12,7 +12,7 @@
 
 FactoryBot.define do
   factory :general_information do
-    key { Faker::Lorem.word }
+    key { Faker::Lorem.unique.word }
     title { Faker::Lorem.sentence }
     text { Faker::Lorem.paragraph }
   end

--- a/spec/factories/target.rb
+++ b/spec/factories/target.rb
@@ -17,9 +17,9 @@
 FactoryBot.define do
   factory :target do
     user
+    topic
     area_lenght { Faker::Number.between(1, 1000) }
     title { Faker::Lorem.word }
-    topic { Target.topics.keys.sample }
     latitude { Faker::Address.latitude }
     longitude { Faker::Address.longitude }
   end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -10,6 +10,6 @@
 
 FactoryBot.define do
   factory :topic do
-    title { Faker::Lorem.word }
+    title { Faker::Lorem.unique.word }
   end
 end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: topics
+#
+#  id         :bigint           not null, primary key
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+FactoryBot.define do
+  factory :topic do
+    title { Faker::Lorem.word }
+  end
+end

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -6,12 +6,12 @@
 #  user_id     :bigint           not null
 #  area_lenght :integer          not null
 #  title       :string           not null
-#  topic       :integer          not null
 #  latitude    :float            not null
 #  longitude   :float            not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  location    :text
+#  topic_id    :bigint           not null
 #
 
 require 'rails_helper'
@@ -22,19 +22,6 @@ describe Target, type: :model do
 
     it { is_expected.to validate_presence_of(:area_lenght) }
     it { is_expected.to validate_presence_of(:title) }
-    it { is_expected.to validate_presence_of(:topic) }
-    it {
-      is_expected.to define_enum_for(:topic)
-        .with_values(football: 0,
-                     travel: 1,
-                     politics: 2,
-                     art: 3,
-                     dating: 4,
-                     music: 5,
-                     movies: 6,
-                     series: 7,
-                     food: 8)
-    }
     it {
       is_expected.to validate_numericality_of(:latitude)
         .is_less_than_or_equal_to(90)
@@ -51,5 +38,6 @@ describe Target, type: :model do
     subject { create(:target) }
 
     it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:topic) }
   end
 end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: topics
+#
+#  id         :bigint           not null, primary key
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require 'rails_helper'
+
+describe Topic, type: :model do
+  describe 'validations' do
+    subject { build(:topic) }
+
+    it { is_expected.to validate_presence_of(:title) }
+  end
+
+  describe 'associations' do
+    subject { create(:topic) }
+
+    it { is_expected.to have_many(:targets) }
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -15,6 +15,7 @@ describe Topic, type: :model do
     subject { build(:topic) }
 
     it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_uniqueness_of(:title).case_insensitive }
   end
 
   describe 'associations' do

--- a/spec/request/api/v1/targets/compatible_spec.rb
+++ b/spec/request/api/v1/targets/compatible_spec.rb
@@ -45,7 +45,11 @@ describe 'GET api/v1/targets/compatible', type: :request do
               user_id: new_user.id,
               area_lenght: new_target.area_lenght,
               title: new_target.title,
-              topic: new_target.topic,
+              topic:
+              {
+                id: target.topic.id,
+                title: target.topic.title
+              },
               latitude: be_within(decimal_scale).of(new_target.latitude),
               longitude: be_within(decimal_scale).of(new_target.longitude)
             }
@@ -93,8 +97,11 @@ describe 'GET api/v1/targets/compatible', type: :request do
             id: target1.id,
             user_id: user2.id,
             area_lenght: target1.area_lenght,
-            title: target1.title,
-            topic: target1.topic,
+            topic:
+              {
+                id: topic1.id,
+                title: topic1.title
+              },
             latitude: be_within(decimal_scale).of(target1.latitude),
             longitude: be_within(decimal_scale).of(target1.longitude)
           },
@@ -102,8 +109,11 @@ describe 'GET api/v1/targets/compatible', type: :request do
             id: target2.id,
             user_id: user3.id,
             area_lenght: target2.area_lenght,
-            title: target2.title,
-            topic: target2.topic,
+            topic:
+              {
+                id: topic1.id,
+                title: topic1.title
+              },
             latitude: be_within(decimal_scale).of(target2.latitude),
             longitude: be_within(decimal_scale).of(target2.longitude)
           }

--- a/spec/request/api/v1/targets/create_spec.rb
+++ b/spec/request/api/v1/targets/create_spec.rb
@@ -48,7 +48,7 @@ describe 'Create Targets', type: :request do
         let!(:new_target) do
           build(:target,
                 user: new_user,
-                topic_id: topic.id,
+                topic: topic,
                 latitude: params[:target][:latitude] + 0.01,
                 longitude: params[:target][:longitude])
         end

--- a/spec/request/api/v1/targets/create_spec.rb
+++ b/spec/request/api/v1/targets/create_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe 'Create Targets', type: :request do
   let!(:user) { create(:user, :confirmed) }
+  let!(:topic) { create(:topic) }
   let(:params) do
     {
-      target: attributes_for(:target)
+      target: attributes_for(:target, topic_id: topic.id)
     }
   end
 
@@ -31,7 +32,11 @@ describe 'Create Targets', type: :request do
               user_id: user.id,
               area_lenght: params[:target][:area_lenght],
               title: params[:target][:title],
-              topic: params[:target][:topic],
+              topic:
+              {
+                id: topic.id,
+                title: topic.title
+              },
               latitude: be_within(decimal_scale).of(params[:target][:latitude]),
               longitude: be_within(decimal_scale).of(params[:target][:longitude])
             }
@@ -43,7 +48,7 @@ describe 'Create Targets', type: :request do
         let!(:new_target) do
           build(:target,
                 user: new_user,
-                topic: params[:target][:topic],
+                topic_id: topic.id,
                 latitude: params[:target][:latitude] + 0.01,
                 longitude: params[:target][:longitude])
         end
@@ -89,6 +94,21 @@ describe 'Create Targets', type: :request do
     context 'when the request is fail' do
       before do
         params[:target][:title] = ''
+        post api_v1_targets_path, params: params, headers: auth_header
+      end
+
+      it 'is expected an error response' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'is expected an error message' do
+        expect(response.body).to include_json(error: I18n.t('api.errors.invalid_model'))
+      end
+    end
+
+    context "when the topic doesn't exist" do
+      before do
+        params[:target][:topic_id] = 0
         post api_v1_targets_path, params: params, headers: auth_header
       end
 

--- a/spec/request/api/v1/targets/index_spec.rb
+++ b/spec/request/api/v1/targets/index_spec.rb
@@ -16,8 +16,7 @@ describe 'List Targets', type: :request do
       end
 
       it 'is expected that response contains at least one' do
-        body = JSON response.body
-        targets = json_value(body, 'targets')
+        targets = json_value(response.parsed_body, 'targets')
         expect(targets).to_not be_empty
         expect(targets.count).to be(3)
       end

--- a/spec/request/api/v1/topics/index_spec.rb
+++ b/spec/request/api/v1/topics/index_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'GET api/v1/topics', type: :request do
+  let!(:user) { create(:user) }
+  let!(:topic) { create(:topic) }
+
+  context 'when the request is succesful' do
+    before do
+      get api_v1_topics_path, headers: auth_header
+    end
+
+    it 'is expected a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'is expected that response contains at least one' do
+      topics = json_value(response.parsed_body, 'topics')
+      expect(topics.count).to be >= 1
+    end
+
+    it 'is expected that response contains at least some body data' do
+      expect(response.body).to include_json(
+        topics: a_collection_including(
+          a_hash_including('id' => topic.id, 'title' => topic.title)
+        )
+      )
+    end
+  end
+
+  context 'when the user is not logged in' do
+    it 'is expected an unauthorized response' do
+      get api_v1_topics_path
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/request/api/v1/topics/index_spec.rb
+++ b/spec/request/api/v1/topics/index_spec.rb
@@ -19,11 +19,8 @@ describe 'GET api/v1/topics', type: :request do
     end
 
     it 'is expected that response contains at least some body data' do
-      expect(response.body).to include_json(
-        topics: a_collection_including(
-          a_hash_including('id' => topic.id, 'title' => topic.title)
-        )
-      )
+      topics = json_value(response.parsed_body, 'topics')
+      expect(topics).to include_unordered_json([{ id: topic.id, title: topic.title }])
     end
   end
 

--- a/spec/support/shared_contexts/near_targets.rb
+++ b/spec/support/shared_contexts/near_targets.rb
@@ -12,7 +12,7 @@ shared_context 'near targets', shared_context: :metadata do
     create(:target,
            user: user2,
            title: 'Montenvideo Shopping',
-           topic_id: topic1.id,
+           topic: topic1,
            latitude: -34.9036534,
            longitude: -56.1449722,
            area_lenght: 4)
@@ -23,7 +23,7 @@ shared_context 'near targets', shared_context: :metadata do
     create(:target,
            user: user3,
            title: 'Nuevocentro Shopping',
-           topic_id: topic1.id,
+           topic: topic1,
            latitude: -34.8756006,
            longitude: -56.1771999,
            area_lenght: 2)
@@ -34,7 +34,7 @@ shared_context 'near targets', shared_context: :metadata do
     create(:target,
            user: user2,
            title: 'Rural del prado',
-           topic_id: topic2.id,
+           topic: topic2,
            latitude: -34.8719561,
            longitude: -56.2144232,
            area_lenght: 4)
@@ -45,9 +45,9 @@ shared_context 'near targets', shared_context: :metadata do
     create(:target,
            user: user3,
            title: 'Portones Shopping',
-           topic_id: topic1.id,
-           latitude: -34.9033253,
-           longitude: -56.1800601,
+           topic: topic1,
+           latitude: -34.8811386,
+           longitude: -56.0813423,
            area_lenght: 2)
   end
 

--- a/spec/support/shared_contexts/near_targets.rb
+++ b/spec/support/shared_contexts/near_targets.rb
@@ -3,12 +3,16 @@ shared_context 'near targets', shared_context: :metadata do
   let!(:user2) { create(:user, :confirmed) }
   let!(:user3) { create(:user, :confirmed) }
 
-  # target - Montenvideo Shopping - 5.14 km - compatible: Y
+  # topics
+  let!(:topic1) { create(:topic) }
+  let!(:topic2) { create(:topic) }
+
+  # target - Montenvideo Shopping - 7km - compatible: Y
   let!(:target1) do
     create(:target,
            user: user2,
            title: 'Montenvideo Shopping',
-           topic: Target.topics.key(1),
+           topic_id: topic1.id,
            latitude: -34.9036534,
            longitude: -56.1449722,
            area_lenght: 4)
@@ -19,7 +23,7 @@ shared_context 'near targets', shared_context: :metadata do
     create(:target,
            user: user3,
            title: 'Nuevocentro Shopping',
-           topic: Target.topics.key(1),
+           topic_id: topic1.id,
            latitude: -34.8756006,
            longitude: -56.1771999,
            area_lenght: 2)
@@ -30,7 +34,7 @@ shared_context 'near targets', shared_context: :metadata do
     create(:target,
            user: user2,
            title: 'Rural del prado',
-           topic: Target.topics.key(8),
+           topic_id: topic2.id,
            latitude: -34.8719561,
            longitude: -56.2144232,
            area_lenght: 4)
@@ -41,9 +45,9 @@ shared_context 'near targets', shared_context: :metadata do
     create(:target,
            user: user3,
            title: 'Portones Shopping',
-           topic: Target.topics.key(1),
-           latitude: -34.8811386,
-           longitude: -56.0813423,
+           topic_id: topic1.id,
+           latitude: -34.9033253,
+           longitude: -56.1800601,
            area_lenght: 2)
   end
 
@@ -52,7 +56,7 @@ shared_context 'near targets', shared_context: :metadata do
     {
       target: attributes_for(:target,
                              title: 'Rootstrap',
-                             topic: Target.topics.key(1),
+                             topic_id: topic1.id,
                              latitude: -34.9071206,
                              longitude: -56.2011391,
                              area_lenght: 4)


### PR DESCRIPTION
## Manage topics from admin page in Target MVD

#### Trello board reference:

* [As an admin I should be able to create/edit/delete new topics for targets](https://trello.com/c/7kfPDPvH)
* [As an admin I should be able to filter targets by topic](https://trello.com/c/xi7UUxGI)

---

#### Description:

* Refactor topic entity from enum to table 
* Add active admin pages to topics